### PR TITLE
vBumpUp @msgpack w/o *.mjs

### DIFF
--- a/examples/transit-react-basic/package.json
+++ b/examples/transit-react-basic/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"eos-transit-algosigner-provider": "1.0.0",
-		"@msgpack/msgpack": "^2.0.0",
+		"@msgpack/msgpack": "^2.5.1",
 		"@open-rights-exchange/chainjs": "0.24.6",
 		"@babel/runtime": "^7.1.2",
 		"emotion": "^9.2.10",

--- a/examples/transit-react-basic/src/PaymentPage.tsx
+++ b/examples/transit-react-basic/src/PaymentPage.tsx
@@ -7,7 +7,7 @@ import {
   AlgorandChainActionType,
 } from "@open-rights-exchange/chainjs/dist/chains/algorand_1/models";
 
-import * as msgpack from "@msgpack/msgpack";
+import * as msgpack from "@msgpack/msgpack/dist";
 
 import { AuthContext } from "./context";
 

--- a/examples/transit-react-basic/src/PaymentPage.tsx
+++ b/examples/transit-react-basic/src/PaymentPage.tsx
@@ -6,7 +6,8 @@ import {
   AlgorandActionPaymentParams,
   AlgorandChainActionType,
 } from "@open-rights-exchange/chainjs/dist/chains/algorand_1/models";
-
+// NOTE: @msgpack/msgpack/dist is required due to packaging error in msgpack that causes build errors (for mjs files) in other projects 
+// See: https://github.com/msgpack/msgpack-javascript/issues/169
 import * as msgpack from "@msgpack/msgpack/dist";
 
 import { AuthContext } from "./context";

--- a/packages/eos-transit-algosigner-provider/package.json
+++ b/packages/eos-transit-algosigner-provider/package.json
@@ -18,7 +18,7 @@
 		"lint": "../../node_modules/.bin/tslint -c ../../tslint.json -p ./tsconfig.json"
 	},
 	"dependencies": {
-		"@msgpack/msgpack": "^2.0.0",
+		"@msgpack/msgpack": "^2.5.1",
 		"hi-base32": "^0.5.0"
 	},
 	"devDependencies": {

--- a/packages/eos-transit-algosigner-provider/src/helper.ts
+++ b/packages/eos-transit-algosigner-provider/src/helper.ts
@@ -1,5 +1,5 @@
 import * as base32 from 'hi-base32';
-import * as msgpack from '@msgpack/msgpack';
+import * as msgpack from '@msgpack/msgpack/dist';
 import {
   AlgoNetworkType,
   AlgoSignerAccountInfo,

--- a/packages/eos-transit-algosigner-provider/src/helper.ts
+++ b/packages/eos-transit-algosigner-provider/src/helper.ts
@@ -1,4 +1,6 @@
 import * as base32 from 'hi-base32';
+// NOTE: @msgpack/msgpack/dist is required due to packaging error in msgpack that causes build errors (for mjs files) in other projects 
+// See: https://github.com/msgpack/msgpack-javascript/issues/169
 import * as msgpack from '@msgpack/msgpack/dist';
 import {
   AlgoNetworkType,

--- a/packages/eos-transit-algosigner-provider/src/plugin.ts
+++ b/packages/eos-transit-algosigner-provider/src/plugin.ts
@@ -21,7 +21,7 @@ import {
   AlgoSignerWalletProviderOptions,
   TxnObject,
 } from './types';
-import * as msgpack from '@msgpack/msgpack';
+import * as msgpack from '@msgpack/msgpack/dist';
 import { Buffer } from 'buffer';
 
 let _network: AlgoNetworkType = AlgoNetworkType.MainNet;

--- a/packages/eos-transit-algosigner-provider/src/plugin.ts
+++ b/packages/eos-transit-algosigner-provider/src/plugin.ts
@@ -21,6 +21,8 @@ import {
   AlgoSignerWalletProviderOptions,
   TxnObject,
 } from './types';
+// NOTE: @msgpack/msgpack/dist is required due to packaging error in msgpack that causes build errors (for mjs files) in other projects 
+// See: https://github.com/msgpack/msgpack-javascript/issues/169
 import * as msgpack from '@msgpack/msgpack/dist';
 import { Buffer } from 'buffer';
 


### PR DESCRIPTION
Updated @msgpack to v2.5.1
Removed *.mjs files from tree (using ./dist)